### PR TITLE
Allow domain and search to be empty in configdrive_resolv

### DIFF
--- a/templates/resolv.conf.j2
+++ b/templates/resolv.conf.j2
@@ -1,9 +1,9 @@
 #jinja2: trim_blocks: "true", lstrip_blocks: "true"
 
-{% if configdrive_resolv['domain'] is defined -%}
+{% if configdrive_resolv.get('domain') -%}
 domain {{ configdrive_resolv['domain'] }}
 {% endif -%}
-{% if configdrive_resolv['search'] is defined -%}
+{% if configdrive_resolv.get('search') -%}
 search {{ configdrive_resolv['search'] }}
 {% endif -%}
 {% for ns in configdrive_resolv['dns'] -%}


### PR DESCRIPTION
This allows us to set configdrive_resolv with a fixed format, where some fields
are empty. For example:

configdrive_resolv:
  domain: "{{ domain | default }}"
  search: "{{ search | default }}"
  dns: "{{ dns | default }}"