### PR TITLE
Use remote_src for copy

### DIFF
--- a/tasks/configdrive.yml
+++ b/tasks/configdrive.yml
@@ -55,6 +55,7 @@
     owner: "{{ configdrive_user | default(omit) }}"
     group: "{{ configdrive_group | default(omit) }}"
     mode: 0644
+    remote_src: True
   with_items:
     - "openstack/2012-08-10"
     - "openstack/latest"
@@ -65,4 +66,3 @@
     genisoimage -R -V "{{ configdrive_voume_name }}" "{{ configdrive_config_dir }}/{{ configdrive_instance_dir }}" 
     | gzip -c | base64 > "{{ configdrive_volume_path }}/{{ configdrive_instance_dir }}.gz"
   when: configdrive_volume_path is defined and not configdrive_volume_path is none
-


### PR DESCRIPTION
Without remote_src, this module tries to copy the user_data file from the local machine, while it was created on the remote machine.