### PR TITLE
Fix for running on Python 3

### DIFF
--- a/templates/meta_data.json.j2
+++ b/templates/meta_data.json.j2
@@ -14,7 +14,7 @@
     "hostname": "{{ configdrive_fqdn }}",
     "name": "{{ configdrive_name }}",
     "meta": {
-{%- for (key, value) in configdrive_meta.iteritems() %}
+{%- for (key, value) in configdrive_meta.items() %}
         "{{ key }}": "{{ value }}"{% if not loop.last %},{% endif %}
 {%- endfor %} 
     },


### PR DESCRIPTION
Using iteritems() on a dict doesn't work in Python 3. Use items()
instead.