### PR TITLE
Fix boot failure on CentOS without gateway

### DIFF
--- a/templates/network_info.json.j2
+++ b/templates/network_info.json.j2
@@ -35,21 +35,20 @@
         ],
 {%- endif %}
         "routes": [
-{%- if dev.route is defined %}
-{%- for i in dev.route %}
+{%- set route_list=[] %}
+{%- if dev.gateway is defined %}
+{%- set _=route_list.append({"network": "0.0.0.0", "netmask": "0.0.0.0", "gateway": dev.gateway}) %}
+{%- endif %}
+{%- for i in dev.route | default([]) %}
+{%- set _=route_list.append({"network": i.network, "netmask": i.netmask, "gateway": i.gateway}) %}
+{%- endfor %}
+{%- for i in route_list %}
             {
                 "network": "{{ i.network }}",
                 "netmask": "{{ i.netmask}}",
                 "gateway": "{{ i.gateway }}"
-            },
+            }{% if not loop.last %},{% endif %}
 {%- endfor %}
-{%- endif %}     
-            {
-                "network": "0.0.0.0",
-                "netmask": "0.0.0.0"{% if dev.gateway is defined %},
-                "gateway": "{{ dev.gateway }}"
-{%- endif %}
-            }            
         ]
     }{% if not loop.last %},{% endif %}
 {%- endfor %}


### PR DESCRIPTION
Seen on CentOS 8, but probably more related to cloud-init. For a host
with network configuration where at least one interface does not have a
gateway.

    is_ipv6 = subnet.get('ipv6') or is_ipv6_addr(route['gateway'])
    KeyError: 'gateway'

This happens because there is an entry in the routes list in
network_info.json that looks like this:

    {"network": "0.0.0.0", "netmask": "0.0.0.0"}

This change fixes the issue by only adding a default route if a gateway
has been specified for an interface.

Fixes: #6