### PR TITLE
Support distros without support for globs in interfaces config

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -63,3 +63,6 @@ configdrive_config_dir_delete: False
 #configdrive_user:
 #configdrive_group:
 
+# Whether Debian network configuration in /etc/network/interfaces supports a
+# glob in the include path.
+configdrive_debian_network_interfaces_supports_glob: true

--- a/templates/interfaces.j2
+++ b/templates/interfaces.j2
@@ -6,5 +6,11 @@ auto lo
 iface lo inet loopback
 
 # Load the configuration from the folder
+{% if configdrive_debian_network_interfaces_supports_glob | bool %}
 source /etc/network/interfaces.d/*
+{% else %}
+{% for dev in configdrive_network_device_list %}
+source /etc/network/interfaces.d/ifcfg-{{ dev["device"] }}
+{% endfor %}
+{% endif %}
 


### PR DESCRIPTION
Some distributions (including Cirros) do not support using path globbing
in /etc/network/interfaces to include other configuration files. This
prevents configdrives built using this role from providing network
configuration for them.

This change fixes the issue by providing a
'configdrive_debian_network_interfaces_supports_glob' flag which may be
set to 'false'.