### PR TITLE
Use ansible_facts to reference facts

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -4,7 +4,7 @@
     name: "{{ item.key }}{{ '-' + item.version | default('*') }}"
     state: "{{ item.state | default('present') }}"
   with_dict: configdrive_packages
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts.os_family == 'RedHat'
   tags: ["redhat"]
 
 - name: Debian - Install required packages
@@ -12,5 +12,5 @@
     name: "{{ item.key }}{{ '=' + item.version | default('*') }}"
     state: "{{ item.state | default('present') }}"
   with_dict: configdrive_packages
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts.os_family == 'Debian'
   tags: ["debian"]

--- a/tasks/network.yml
+++ b/tasks/network.yml
@@ -89,7 +89,7 @@
 
 - name: Setup route configuration for RedHat
   template: 
-    src: "route_{{ ansible_os_family }}.j2"
+    src: "route_{{ ansible_facts.os_family }}.j2"
     dest: "{{ _configdrive_content_path }}/{{ configdrive_os_network_path }}/route-{{ item.device }}"
     owner: "{{ configdrive_user | default(omit) }}"
     group: "{{ configdrive_group | default(omit) }}"


### PR DESCRIPTION
By default, Ansible injects a variable for every fact, prefixed with
ansible_. This can result in a large number of variables for each host,
which at scale can incur a performance penalty. Ansible provides a
configuration option [0] that can be set to False to prevent this
injection of facts. In this case, facts should be referenced via
ansible_facts.<fact>.

This change updates all references to Ansible facts within Kolla Ansible
from using individual fact variables to using the items in the
ansible_facts dictionary. This allows users to disable fact variable
injection in their Ansible configuration, which may provide some
performance improvement.

This change disables fact variable injection in the ansible
configuration used in CI, to catch any attempts to use the injected
variables.

[0] https://docs.ansible.com/ansible/latest/reference_appendices/config.html#inject-facts-as-vars