### PR TITLE
Convert configdrive_instance_dir to default variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,7 @@ configdrive_check_required_packages: True
 # on the family!
 configdrive_os_family: "Debian"
 configdrive_uuid: "uuid-test-01"
+configdrive_instance_dir: "{{ configdrive_uuid }}"
 configdrive_fqdn: "test.example.com"
 configdrive_name: "test"
 configdrive_ssh_public_key:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,10 +12,6 @@
   include_vars: "{{ configdrive_os_family }}.yml"
   tags: ["distribution"]
 
-- name: Setup configdrive instance folder
-  set_fact: configdrive_instance_dir="{{ configdrive_uuid }}"
-  when: configdrive_instance_dir is not defined or configdrive_instance_dir is none
-
 - name: Create configdrive metadata folders
   file:
     path: "{{ configdrive_config_dir }}/{{ configdrive_instance_dir }}/{{ item }}"


### PR DESCRIPTION
The issue was that the role does not work in a loop as the variable gets
defined in the first iteration giving an error like:

```
TASK [infra-vms : [custom-vm-2] Ensure configdrive is decoded and decompressed] *********************************************************************************************
fatal: [seed-hypervisor]: FAILED! => {"changed": true, "cmd": "base64 -d /opt/kayobe/images/39f67abd-4ab9-529c-aeeb-877296e893dd.gz | gunzip > /opt/kayobe/images/custom-vm-2.iso\n", "delta": "0:00:00.008269", "end": "2021-08-19 11:14:45.299416", "msg": "non-zero return code", "rc": 1, "start": "2021-08-19 11:14:45.291147", "stderr": "base64: /opt/kayobe/images/39f67abd-4ab9-529c-aeeb-877296e893dd.gz: No such file or directory\n\ngzip: stdin: unexpected end of file", "stderr_lines": ["base64: /opt/kayobe/images/39f67abd-4ab9-529c-aeeb-877296e893dd.gz: No such file or directory", "", "gzip: stdin: unexpected end of file"], "stdout": "", "stdout_lines": []}
```