### PR TITLE
Support VLAN links network_info.json

### DIFF
--- a/templates/network_info.json.j2
+++ b/templates/network_info.json.j2
@@ -4,12 +4,24 @@
 {%- set device_list=configdrive_network_device_list | map(attribute='device') | list %}
     "links": [
 {%- for dev in configdrive_network_device_list %}
+{%- if dev.type | default == "vlan" and dev.backend is defined and dev.backend[0] not in device_list %}
+        {
+            "name": "{{ dev.backend[0] }}",
+            "id": "{{ dev.backend[0] }}",
+            "type": "phy"
+        },
+{%- endif %}
         {
             "name": "{{ dev.device }}",
             "id": "{{ dev.device }}",
             "type": "{{ dev.type | default('phy') }}",
-{%- if dev.mac is defined %}
+{%- if dev.type | default == "vlan" and dev.backend is defined %}
+            "vlan_id": {{ dev.device.split('.')[1] }},
+            "vlan_link": "{{ dev.backend[0] }}",
+            "vlan_mac_address": {% if dev.mac is defined %}"{{ dev.mac }}"{% else %}null{% endif %},
+{%- elif dev.mac is defined %}
             "ethernet_mac_address": "{{ dev.mac }}",
+{%- endif %}
 {%- endif %}
             "mtu": "{{ dev.mtu | default(1500) }}"
         }{% if not loop.last %},{% endif %}


### PR DESCRIPTION
With older versions of cloud-init (e.g. CentOS 7), it seemed to be
possible to specify an interface named <link>.<vlan>, and cloud-init
would assume that this is a VLAN interface on <link> with VLAN ID
<vlan>.

In more recent versions of cloud-init (e.g. CentOS 8), several
additional parameters are required in more recent cloud-init versions:

* vlan_id
* vlan_link
* vlan_mac_address

While the MAC address is required, it does seem possible to set it to
null. Additionally, the backend device must be listed in the
configuration.