### PR TITLE
Fix network_info.json Jinja syntax

### DIFF
--- a/templates/network_info.json.j2
+++ b/templates/network_info.json.j2
@@ -22,7 +22,6 @@
 {%- elif dev.mac is defined %}
             "ethernet_mac_address": "{{ dev.mac }}",
 {%- endif %}
-{%- endif %}
             "mtu": "{{ dev.mtu | default(1500) }}"
         }{% if not loop.last %},{% endif %}
 {%- endfor %}


### PR DESCRIPTION
Included an unnecessary endif.