### PR TITLE
Only create network stanza if dev.address is defined

### DIFF
--- a/templates/network_info.json.j2
+++ b/templates/network_info.json.j2
@@ -28,13 +28,13 @@
     ],
     "networks": [
 {%- for dev in configdrive_network_device_list %}
+{%- if dev.address is not defined %}
+{%- else %}
     {
         "id": "{{ dev.type | default('phy') }}-{{ dev.device }}",
         "type": "ipv4",
         "link": "{{ dev.device }}",
-{%- if dev.address is defined %}
         "ip_address": "{{ dev.address }}",
-{%- endif %}
 {%- if dev.netmask is defined %}
         "netmask": "{{ dev.netmask }}",
 {%- endif %}
@@ -62,6 +62,7 @@
 {%- endfor %}
         ]
     }{% if not loop.last %},{% endif %}
+{%- endif %}   
 {%- endfor %}
     ],
     "services": [


### PR DESCRIPTION
I recently ran into an issue using the role where I was configuring an interface with two VLAN subinterfaces, with the config:

* eth0 (mtu 9000, no address)
* eth0.1 (mtu 9000, address defined)
* eth0.2 (mtu 1500, address defined)

This would result in an invalid stanza in the networks list in network_info.json, where ID, link and type are defined for eth0, but without an address cloud-init fails.

This patch only creates an entry in `networks` if it has an address defined.