### PR TITLE
Only create network stanza if dev.address is defined

### DIFF
--- a/templates/network_info.json.j2
+++ b/templates/network_info.json.j2
@@ -28,13 +28,13 @@
     ],
     "networks": [
 {%- for dev in configdrive_network_device_list %}
+{%- if dev.address is not defined %}
+{%- else %}
     {
         "id": "{{ dev.type | default('phy') }}-{{ dev.device }}",
         "type": "ipv4",
         "link": "{{ dev.device }}",
-{%- if dev.address is defined %}
         "ip_address": "{{ dev.address }}",
-{%- endif %}
 {%- if dev.netmask is defined %}
         "netmask": "{{ dev.netmask }}",
 {%- endif %}
@@ -62,6 +62,7 @@
 {%- endfor %}
         ]
     }{% if not loop.last %},{% endif %}
+{%- endif %}   
 {%- endfor %}
     ],
     "services": [

--- a/templates/network_info.json.j2
+++ b/templates/network_info.json.j2
@@ -27,9 +27,7 @@
 {%- endfor %}
     ],
     "networks": [
-{%- for dev in configdrive_network_device_list %}
-{%- if dev.address is not defined %}
-{%- else %}
+{%- for dev in configdrive_network_device_list | selectattr("address", "defined") %}
     {
         "id": "{{ dev.type | default('phy') }}-{{ dev.device }}",
         "type": "ipv4",
@@ -62,7 +60,6 @@
 {%- endfor %}
         ]
     }{% if not loop.last %},{% endif %}
-{%- endif %}   
 {%- endfor %}
     ],
     "services": [


### PR DESCRIPTION
This builds on the work in https://github.com/jriguera/ansible-role-configdrive/pull/15, simply skipping adding an element to the `networks` stanza if a network device definition is missing an `address`.