### PR TITLE
Fix cloud config schema error

### DIFF
--- a/templates/network_info.json.j2
+++ b/templates/network_info.json.j2
@@ -22,7 +22,7 @@
 {%- elif dev.mac is defined %}
             "ethernet_mac_address": "{{ dev.mac }}",
 {%- endif %}
-            "mtu": "{{ dev.mtu | default(1500) }}"
+            "mtu": {{ dev.mtu | default(1500) | int }}
         }{% if not loop.last %},{% endif %}
 {%- endfor %}
     ],


### PR DESCRIPTION
Recent versions of cloud-init show the following warning:

    network-config-v1 failed schema validation! You may run 'sudo cloud-init schema --system' to check the details.

This is because the mtu value is a string instead of an integer:

    Error: Cloud config schema errors: config.0.mtu: '1442' is not of type 'integer', 'null'