### PR TITLE
Switch from genisoimage to xorriso

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ user to login to the host, and other files like `/etc/hosts` or
 file https://help.ubuntu.com/community/CloudInit
 
 
-Ansible 2.0, works with Ubuntu Trusty, Xenial and Centos 7
+Ansible 2.0, works with Ubuntu Jammy and above, RHEL 8 and above.
 
 
 Requirements
@@ -31,7 +31,7 @@ Requirements
 
 It does not install packages on the target host, it just creates the 
 folders and files needed to create a config-drive volume, So, be 
-aware that you probably you will need to install `genisoimage`, 
+aware that you probably you will need to install `xorriso`,
 `base64` and `gzip`.
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-# Check if genisoimage and other packages which are needed to create
+# Check if xorriso and other packages which are needed to create
 # configdrive are installed. The check can be disabled to speed up (a bit)
 # the role (assuming the packages are already installed)
 configdrive_check_required_packages: True

--- a/site.yml
+++ b/site.yml
@@ -3,7 +3,7 @@
   become: true
 
   pre_tasks:
-    - apt: name=genisoimage state=present
+    - apt: name=xorriso state=present
 
   roles:
     - role: .

--- a/tasks/configdrive.yml
+++ b/tasks/configdrive.yml
@@ -62,6 +62,6 @@
 
 - name: Create configdrive volume file
   shell: >
-    genisoimage -R -V "{{ configdrive_voume_name }}" "{{ configdrive_config_dir }}/{{ configdrive_instance_dir }}" 
+    xorriso -as mkisofs -R -V "{{ configdrive_voume_name }}" "{{ configdrive_config_dir }}/{{ configdrive_instance_dir }}"
     | gzip -c | base64 > "{{ configdrive_volume_path }}/{{ configdrive_instance_dir }}.gz"
   when: configdrive_volume_path is defined and not configdrive_volume_path is none

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,7 +3,7 @@ configdrive_content_tmproot_dir: "_"
 configdrive_voume_name: "config-2"
 
 configdrive_required_packages:
-  genisoimage:
+  xorriso:
     state: latest
   gzip:
     state: latest


### PR DESCRIPTION
GNU xorriso is better maintained than genisoimage.

Packages are available for Rocky Linux 8/9/10 (in AppStream) and for Ubuntu from the 22.04 (Jammy) release.