### PR TITLE
Ansible 12 compat: trim blocks must be <class 'bool'>

### DIFF
--- a/templates/hosts.j2
+++ b/templates/hosts.j2
@@ -1,4 +1,4 @@
-#jinja2: trim_blocks: "true", lstrip_blocks: "true"
+#jinja2: trim_blocks: True, lstrip_blocks: True
 127.0.0.1	localhost
 127.0.0.1   {{ configdrive_fqdn }} {{ configdrive_name }} 
 

--- a/templates/interfaces.j2
+++ b/templates/interfaces.j2
@@ -1,4 +1,4 @@
-#jinja2: trim_blocks: "true", lstrip_blocks: "true"
+#jinja2: trim_blocks: True, lstrip_blocks: True
 # interfaces(5) file used by ifup(8) and ifdown(8)
 
 # Loopback network interface

--- a/templates/resolv.conf.j2
+++ b/templates/resolv.conf.j2
@@ -1,4 +1,4 @@
-#jinja2: trim_blocks: "true", lstrip_blocks: "true"
+#jinja2: trim_blocks: True, lstrip_blocks: True
 
 {% if configdrive_resolv.get('domain') -%}
 domain {{ configdrive_resolv['domain'] }}


### PR DESCRIPTION
```
Syntax error in template: TemplateOverrides.trim_blocks must be <class 'bool'> instead of <class 'str'>
Origin: /home/zuul/kayobe-venv/share/kayobe/ansible/roles/jriguera.configdrive/templates/resolv.conf.j2

fatal: [seed-hypervisor]: FAILED! =>
    changed: false
    msg: 'Task failed: Syntax error in template: TemplateOverrides.trim_blocks must be
        <class ''bool''> instead of <class ''str''>'
```