### PR TITLE
Fix non-boolean conditionals for dict/string variables

### DIFF
--- a/tasks/configdrive.yml
+++ b/tasks/configdrive.yml
@@ -58,7 +58,7 @@
   with_items:
     - "openstack/2012-08-10"
     - "openstack/latest"
-  when: configdrive_config_user_data_path is defined and configdrive_config_user_data_path
+  when: configdrive_config_user_data_path is defined and configdrive_config_user_data_path is truthy
 
 - name: Create configdrive volume file
   shell: >

--- a/tasks/network.yml
+++ b/tasks/network.yml
@@ -46,7 +46,7 @@
     owner: "{{ configdrive_user | default(omit) }}"
     group: "{{ configdrive_group | default(omit) }}"
     mode: 0644
-  when: configdrive_resolv is defined and configdrive_resolv
+  when: configdrive_resolv is defined and configdrive_resolv is truthy
 
 - name: Setup static hosts file
   template:
@@ -55,7 +55,7 @@
     owner: "{{ configdrive_user | default(omit) }}"
     group: "{{ configdrive_group | default(omit) }}"
     mode: 0644
-  when: configdrive_hosts is defined and configdrive_hosts
+  when: configdrive_hosts is defined and configdrive_hosts is truthy
 
 - name: Setup network/interfaces for Debian
   template: 


### PR DESCRIPTION
Replace dict/string-valued conditionals with explicit boolean truthiness tests to avoid ansible-core
broken-conditional failures:

- tasks/network.yml: use 'is truthy' for configdrive_resolv and configdrive_hosts which are dict-typed variables
- tasks/configdrive.yml: use 'is truthy' for configdrive_config_user_data_path which is a string path

https://docs.ansible.com/ansible-core/devel/porting_guides/porting_guide_core_2.19.html#broken-conditionals